### PR TITLE
Disable location glyph if using Nita alongside the time

### DIFF
--- a/Tweak/Nita.h
+++ b/Tweak/Nita.h
@@ -25,6 +25,10 @@ BOOL hideBreadcrumbsSwitch = YES;
 - (void)getEmojis;
 @end
 
+@interface _UIStatusBarDisplayItem : NSObject
+@property (nonatomic, weak, readonly) id item;
+@end
+
 @interface WACurrentForecast : NSObject
 @property(assign, nonatomic)long long conditionCode;
 - (void)setConditionCode:(long long)arg1;

--- a/Tweak/Nita.x
+++ b/Tweak/Nita.x
@@ -111,6 +111,22 @@
 
 %end
 
+%hook _UIStatusBarDisplayItem
+
+- (void)setEnabled:(BOOL)arg1 {
+
+	%orig;
+
+	if(!alongsideTimeSwitch) return;
+
+	if([[self item] isKindOfClass:%c(_UIStatusBarIndicatorLocationItem)])
+
+		%orig(NO);
+
+}
+
+%end
+
 %hook SBDeviceApplicationSceneStatusBarBreadcrumbProvider
 
 + (BOOL)_shouldAddBreadcrumbToActivatingSceneEntity:(id)arg1 sceneHandle:(id)arg2 withTransitionContext:(id)arg3 { // hide breadcrumbs


### PR DESCRIPTION
Hey, so I started using this option in Nita for a while now, and the glyph icon didn't really bother me, but since I also don't mind having it I thought about removing it. Because sometimes the whole string resizes so they all fit, or sometimes the glyph just gets cut out. I'm also opening as draft because I don't know if this should be default behavior or add an option for it. If you want an option I can continue working on it, or if not I can just mark it ready for merge. If there aren't plans for merging at all that's okay, but I wish you will anyways haha, idk, seems like a good addition.
Also ugh, I hate the status bar lol, that looks so simple but it took me a while to figure it out.